### PR TITLE
Added support for props.innerHTML

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -42,7 +42,9 @@ module.exports = function init(modules) {
 
     // Close tag, if needed
     if (VOID_ELEMENTS[tagName] !== true && !svg || svg && CONTAINER_ELEMENTS[tagName] === true) {
-      if (vnode.text) {
+      if (vnode.data && vnode.data.props && vnode.data.props.innerHTML) {
+        tag.push(vnode.data.props.innerHTML);
+      } else if (vnode.text) {
         tag.push(vnode.text);
       } else if (vnode.children) {
         vnode.children.forEach(function (child) {

--- a/lib/modules/attributes.js
+++ b/lib/modules/attributes.js
@@ -56,6 +56,9 @@ function setAttributes(values, target) {
       target['class'] = value.split(' ');
       return;
     }
+    if (key === 'innerHTML') {
+      return;
+    }
     target[key] = value;
   });
 }

--- a/src/init.js
+++ b/src/init.js
@@ -45,7 +45,9 @@ module.exports = function init (modules) {
     // Close tag, if needed
     if ((VOID_ELEMENTS[tagName] !== true && !svg) ||
         (svg && CONTAINER_ELEMENTS[tagName] === true)) {
-      if (vnode.text) {
+      if (vnode.data && vnode.data.props && vnode.data.props.innerHTML) {
+        tag.push(vnode.data.props.innerHTML)
+      } else if (vnode.text) {
         tag.push(vnode.text)
       } else if (vnode.children) {
         vnode.children.forEach(function (child) {

--- a/src/modules/attributes.js
+++ b/src/modules/attributes.js
@@ -54,6 +54,9 @@ function setAttributes (values, target) {
       target['class'] = value.split(' ')
       return
     }
+    if (key === 'innerHTML') {
+      return;
+    }
     target[key] = value
   })
 }


### PR DESCRIPTION
This does two things:

1) It prevents props.innerHTML turning into an HTML attribute
2) If `vnode.data.props.innerHTML` is present, it's written out as the HTML content of the tag