### PR TITLE
Don't ignore values.class when string type

### DIFF
--- a/src/modules/attributes.js
+++ b/src/modules/attributes.js
@@ -31,7 +31,7 @@ module.exports = function attributes (vnode) {
       classes.push(key)
     }
   })
-  classes = union(classes, values.class, parsedClasses).filter(x => x !== '')
+  classes = union(classes, values.class && [values.class], parsedClasses).filter(x => x !== '')
 
   if (classes.length) {
     values.class = classes.join(' ')

--- a/src/modules/attributes.js
+++ b/src/modules/attributes.js
@@ -31,7 +31,7 @@ module.exports = function attributes (vnode) {
       classes.push(key)
     }
   })
-  classes = union(classes, values.class && [values.class], parsedClasses).filter(x => x !== '')
+  classes = union(classes, values.class && [values.class] || parsedClasses).filter(x => x !== '')
 
   if (classes.length) {
     values.class = classes.join(' ')


### PR DESCRIPTION
The lodash.union function ignores arguments that are string type, therefore `values.class` of type string are not added to the `classes` array, and don't end up in the resulting HTML string.

First look at the lodash union function instantiation:
https://github.com/lodash/lodash/blob/master/dist/lodash.js#L7579

The pertinent argument (last one in this version) is `true`. 

Now look at the `baseFlatten` function, where a string is handled when union'izing:
https://github.com/lodash/lodash/blob/master/dist/lodash.js#L2613-2614

...the corresponding argument (isStrict) must be `false` in order for strings to be included in the resulting array. Therefore strings are ignored.

The reason for using `values.class && [values.class]` and not just `[values.class]` is because when `values.class` is undefined and wrapped in array brackets it still registers as an element on the array, so having only `[values.class]` will always produce the class attribute in the HTML string, but empty when `values.class` === undefined (i.e., class="").

Example:
http://esnextb.in/?gist=0512c49748550e57039bce437225081e

```
const vdom = sh('div.wrap', {attrs: {'class': 'one'}}, [sh('div#box', 'contents')])
const vdom1 = sh('div', {attrs: {'class': 'one'}}, [sh('div#box', 'contents')])

console.log(v2h(vdom))
console.log(v2h(vdom1))
```
With `vdom`, `class: one` is lost

The reason `vdom1` works is because when `classes` is a zero length array `values.class` is not overwritten, see https://github.com/acstll/snabbdom-to-html/blob/master/src/modules/attributes.js#L36-L38
